### PR TITLE
bumping minimum required zend-registry version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "ext-iconv": "*",
         "php": ">=7.0.0",
         "diablomedia/zendframework1-exception": "^1.0.0",
-        "diablomedia/zendframework1-registry": "^1.0.0",
+        "diablomedia/zendframework1-registry": "^1.0.2",
         "diablomedia/zendframework1-xml": "^1.0.0",
         "diablomedia/zendframework1-cache": "^1.0.0"
     },


### PR DESCRIPTION
I noticed a php 7.4 (prefer-lowest) build of zf1-date was failing because the version of zf1-registry being used was throwing notices in php 7.4.

To help ease the testing of php 7.4, I'm requiring `1.0.2` for zf1-registry that doesn't throw the notice (offending code has been removed) so even `prefer-lowest` picks up the fixed version.